### PR TITLE
Nav fix

### DIFF
--- a/choisi.html
+++ b/choisi.html
@@ -301,14 +301,16 @@
         
 
          <div class="navbar" id="myNavbar">
-              <div class="navbar-inner">
-             <a href="index.html">HOME</a>               
-             <a href="choisi.html">CHOISI</a>
-             <a href="linus.html">LINUS BIKES</a>
-             <a href="legit-bud.html">LEGIT BUD STORE</a>
-             <a href="about.html">ABOUT</a>
-             <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
-               </div>
+            <div class="navbar-inner">
+                <a href="index.html">HOME</a>               
+                <a href="choisi.html">CHOISI</a>
+                <a href="linus.html">LINUS BIKES</a>
+                <a href="legit-bud.html">LEGIT BUD STORE</a>
+                <a href="about.html">ABOUT</a>
+            </div>
+            
+            <a href="javascript:void(0);" class="icon" onclick="myFunction()">&#9776;</a>
+
         </div>
         </main>
         <script>

--- a/css/main.css
+++ b/css/main.css
@@ -580,7 +580,13 @@ i a {
 	display: flex;
 	align-self: flex-end;
 	flex-grow: 0;
-  	}
+	}
+	.navbar {
+		max-width: 300px;
+		/* Use this 300px value to be however big you want the nav area to be */
+		margin: 0 auto;
+
+	}  
   	.navbar.responsive a {
     	float: none;
     	display: block;
@@ -595,7 +601,7 @@ i a {
 		flex-wrap: wrap;
 	}
 	.navbar .navbar-inner a {
-		flex: 1;
+		width: 100%;
 		margin: 0;
 		text-align: left;
 	}

--- a/css/main.css
+++ b/css/main.css
@@ -577,20 +577,28 @@ i a {
 	.navbar a:not(:first-child) {display: none;}
   	.navbar a.icon {
     float: right;
-    display: flex;
-    /*padding-right: 40px;*/
-  	}
-
-  	.navbar.responsive a.icon {
-    	position: absolute;
-    	right: 0;
-    	bottom: 0;
+	display: flex;
+	align-self: flex-end;
+	flex-grow: 0;
   	}
   	.navbar.responsive a {
     	float: none;
     	display: block;
-    	text-align: left;
- 	 }
+		text-align: left;
+	  }
+	.navbar a {
+		padding: 16px 20px;
+	}
+	.navbar .navbar-inner {
+		flex: 1;
+		display: flex;
+		flex-wrap: wrap;
+	}
+	.navbar .navbar-inner a {
+		flex: 1;
+		margin: 0;
+		text-align: left;
+	}
 
 	.challenge-3 img {
 		justify-content: center;


### PR DESCRIPTION
In the PR, this changes your HTML to have your nav icon outside of nav-inner (to let it play better open and closed with flex). It then adjusts some padding and puts a few more layers of flex in. With a lot of navigation design patterns in flex, you usually need a few more layers of flex to get what you're going for.

We then use max-width and margin auto to center the whole thing.

I THINK this is what you're going for, but Instagram isn't a great medium for debugging 😃 